### PR TITLE
wrapt: update to 1.12.1

### DIFF
--- a/extra-python/wrapt/spec
+++ b/extra-python/wrapt/spec
@@ -1,4 +1,3 @@
-VER=1.11.2
+VER=1.12.1
 SRCTBL="https://pypi.io/packages/source/w/wrapt/wrapt-$VER.tar.gz"
-CHKSUM="sha256::565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
-REL=1
+CHKSUM="sha256::b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
wrapt: update to 1.12.1
<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------

<!-- If this topic is part of a security update, please uncomment "Yes,"
     and mark with the `security` label, as well as reference issue number below for priority processing. -->

<!-- Yes - Issue Number: ISSUENUMBER -->
<!-- No -->

<!-- Please uncomment the "Build Order" section if applicable, this is commonly needed in package updates/introduction that affects more than one package. -->

<!--
Build Order
-----------
after setuptool updated
Please describe in what order this pull request should be built.
-->

Architectural Progress
----------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->    
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Secondary Architectural Progress
--------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

----

After the pull request is merged, all package(s) affected must be rebuilt against the `stable` Git tree and environment (only `stable` repository should be enabled in `sources.list`). This section marks the progress above.

Please, make sure the list of architectures below matches the ones above.

Post-Merge Architectural Progress
---------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`   
- [ ] AArch64 `arm64`
<!-- If this package involves a `+32` counterpart, please uncomment the line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the stub below. -->
<!-- - [ ] Architecture-independent `noarch` -->

Post-Merge Secondary Architectural Progress
-------------------------------------------

<!-- Please remove any architecture to which this topic does not apply. -->

Architectural progress for "secondary," or experimental ports does not impede on merging of this topic.

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`

<!-- TODO: CI to auto-fill architectural progress. -->
